### PR TITLE
Exposed llvm-config-path of AFLplusplus in zig-afl-kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ afl_obj.root_module.stack_check = false; // not linking with compiler-rt
 afl_obj.root_module.link_libc = true; // afl runtime depends on libc
 
 // Generate an instrumented executable:
-const afl_fuzz = afl.addInstrumentedExe(b, afl_obj);
+const afl_fuzz = afl.addInstrumentedExe(b, target, optimize, afl_obj);
 
 // Install it
 fuzz.dependOn(&b.addInstallBinFile(afl_fuzz, "myfuzz-afl").step);

--- a/build.zig
+++ b/build.zig
@@ -38,9 +38,17 @@ pub fn addInstrumentedExe(
 
         return exe;
     }
+
+    const llvm_config: []const []const u8 = b.option(
+        []const []const u8,
+        "llvm-config-path",
+        "Path that contains llvm-config",
+    ) orelse &.{};
+
     const afl = afl_kit.builder.dependency("AFLplusplus", .{
         .target = target,
         .optimize = optimize,
+        .@"llvm-config-path" = llvm_config,
     });
 
     const install_tools = b.addInstallDirectory(.{


### PR DESCRIPTION
This exposes the -Dllvm-config-path option of AFLplusplus in zig-afl-kit, so that the user doesn't have to put `llvm-config` in their `$PATH`