### PR TITLE
Allow using system installed AFLPlusPlus

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -75,9 +75,6 @@ pub fn addInstrumentedExe(
             "-o",
         });
     }
-    // Ensure afl-cc runs in llvm mode. Otherwise, instrumentation will be bad.
-    // Using llvm mode gives same coverage as lto mode (only one bc file), but avoids lld requirement.
-    run_afl_cc.setEnvironmentVariable("AFL_CC_COMPILER", "LLVM");
     _ = obj.getEmittedBin(); // hack around build system bug
 
     const fuzz_exe = run_afl_cc.addOutputFileArg(obj.name);

--- a/build.zig
+++ b/build.zig
@@ -76,7 +76,7 @@ pub fn addInstrumentedExe(
         });
     }
     // Ensure afl-cc runs in lto mode. Otherwise, instrumentation will be bad.
-    run_afl_cc.setEnvironmentVariable("MODE", "LTO");
+    run_afl_cc.setEnvironmentVariable("AFL_CC_COMPILER", "LTO");
     _ = obj.getEmittedBin(); // hack around build system bug
 
     const fuzz_exe = run_afl_cc.addOutputFileArg(obj.name);

--- a/build.zig
+++ b/build.zig
@@ -6,8 +6,11 @@ pub fn addInstrumentedExe(
     optimize: std.builtin.OptimizeMode,
     /// Pass null if llvm-config is in PATH
     llvm_config_path: ?[]const []const u8,
+    /// If true will search the path for afl++ instead of compiling from source.
+    /// This is a workaround for issues with zig compiled afl++ and C++11 abi on ubuntu.
+    use_system_afl: bool,
     obj: *std.Build.Step.Compile,
-) std.Build.LazyPath {
+) ?std.Build.LazyPath {
     const afl_kit = b.dependencyFromBuildZig(@This(), .{});
 
     // TODO: validate obj
@@ -41,36 +44,43 @@ pub fn addInstrumentedExe(
         return exe;
     }
 
-    const afl = afl_kit.builder.dependency("AFLplusplus", .{
-        .target = target,
-        .optimize = optimize,
-        .@"llvm-config-path" = llvm_config_path orelse &[_][]const u8{},
-    });
+    var run_afl_cc: *std.Build.Step.Run = undefined;
+    if (!use_system_afl) {
+        const afl = afl_kit.builder.lazyDependency("AFLplusplus", .{
+            .target = target,
+            .optimize = optimize,
+            .@"llvm-config-path" = llvm_config_path orelse &[_][]const u8{},
+        }) orelse return null;
 
-    const install_tools = b.addInstallDirectory(.{
-        .source_dir = std.Build.LazyPath{
-            .cwd_relative = afl.builder.install_path,
-        },
-        .install_dir = .prefix,
-        .install_subdir = "AFLplusplus",
-    });
+        const install_tools = b.addInstallDirectory(.{
+            .source_dir = std.Build.LazyPath{
+                .cwd_relative = afl.builder.install_path,
+            },
+            .install_dir = .prefix,
+            .install_subdir = "AFLplusplus",
+        });
 
-    install_tools.step.dependOn(afl.builder.getInstallStep());
-    _ = obj.getEmittedBin(); // hack around build system bug
-
-    {
-        const run_afl_cc = b.addSystemCommand(&.{
+        install_tools.step.dependOn(afl.builder.getInstallStep());
+        run_afl_cc = b.addSystemCommand(&.{
             b.pathJoin(&.{ afl.builder.exe_dir, "afl-cc" }),
             "-O3",
             "-o",
         });
         run_afl_cc.step.dependOn(&afl.builder.top_level_steps.get("llvm_exes").?.step);
         run_afl_cc.step.dependOn(&install_tools.step);
-        const fuzz_exe = run_afl_cc.addOutputFileArg(obj.name);
-        run_afl_cc.addFileArg(afl_kit.path("afl.c"));
-        run_afl_cc.addFileArg(obj.getEmittedLlvmBc());
-        return fuzz_exe;
+    } else {
+        run_afl_cc = b.addSystemCommand(&.{
+            b.findProgram(&.{"afl-cc"}, &.{}) catch @panic("Could not find 'afl-cc', which is required to build"),
+            "-O3",
+            "-o",
+        });
     }
+    _ = obj.getEmittedBin(); // hack around build system bug
+
+    const fuzz_exe = run_afl_cc.addOutputFileArg(obj.name);
+    run_afl_cc.addFileArg(afl_kit.path("afl.c"));
+    run_afl_cc.addFileArg(obj.getEmittedLlvmBc());
+    return fuzz_exe;
 }
 
 pub fn build(b: *std.Build) !void {

--- a/build.zig
+++ b/build.zig
@@ -62,7 +62,7 @@ pub fn addInstrumentedExe(
 
         install_tools.step.dependOn(afl.builder.getInstallStep());
         run_afl_cc = b.addSystemCommand(&.{
-            b.pathJoin(&.{ afl.builder.exe_dir, "afl-cc" }),
+            b.pathJoin(&.{ afl.builder.exe_dir, "afl-clang-lto" }),
             "-O3",
             "-o",
         });
@@ -70,7 +70,7 @@ pub fn addInstrumentedExe(
         run_afl_cc.step.dependOn(&install_tools.step);
     } else {
         run_afl_cc = b.addSystemCommand(&.{
-            b.findProgram(&.{"afl-cc"}, &.{}) catch @panic("Could not find 'afl-cc', which is required to build"),
+            b.findProgram(&.{"afl-clang-lto"}, &.{}) catch @panic("Could not find 'afl-cc', which is required to build"),
             "-O3",
             "-o",
         });

--- a/build.zig
+++ b/build.zig
@@ -62,7 +62,7 @@ pub fn addInstrumentedExe(
 
         install_tools.step.dependOn(afl.builder.getInstallStep());
         run_afl_cc = b.addSystemCommand(&.{
-            b.pathJoin(&.{ afl.builder.exe_dir, "afl-clang-lto" }),
+            b.pathJoin(&.{ afl.builder.exe_dir, "afl-cc" }),
             "-O3",
             "-o",
         });
@@ -70,11 +70,13 @@ pub fn addInstrumentedExe(
         run_afl_cc.step.dependOn(&install_tools.step);
     } else {
         run_afl_cc = b.addSystemCommand(&.{
-            b.findProgram(&.{"afl-clang-lto"}, &.{}) catch @panic("Could not find 'afl-clang-lto', which is required to build"),
+            b.findProgram(&.{"afl-cc"}, &.{}) catch @panic("Could not find 'afl-cc', which is required to build"),
             "-O3",
             "-o",
         });
     }
+    // Ensure afl-cc runs in lto mode. Otherwise, instrumentation will be bad.
+    run_afl_cc.setEnvironmentVariable("MODE", "LTO");
     _ = obj.getEmittedBin(); // hack around build system bug
 
     const fuzz_exe = run_afl_cc.addOutputFileArg(obj.name);

--- a/build.zig
+++ b/build.zig
@@ -75,8 +75,9 @@ pub fn addInstrumentedExe(
             "-o",
         });
     }
-    // Ensure afl-cc runs in lto mode. Otherwise, instrumentation will be bad.
-    run_afl_cc.setEnvironmentVariable("AFL_CC_COMPILER", "LTO");
+    // Ensure afl-cc runs in llvm mode. Otherwise, instrumentation will be bad.
+    // Using llvm mode gives same coverage as lto mode (only one bc file), but avoids lld requirement.
+    run_afl_cc.setEnvironmentVariable("AFL_CC_COMPILER", "LLVM");
     _ = obj.getEmittedBin(); // hack around build system bug
 
     const fuzz_exe = run_afl_cc.addOutputFileArg(obj.name);

--- a/build.zig
+++ b/build.zig
@@ -70,7 +70,7 @@ pub fn addInstrumentedExe(
         run_afl_cc.step.dependOn(&install_tools.step);
     } else {
         run_afl_cc = b.addSystemCommand(&.{
-            b.findProgram(&.{"afl-clang-lto"}, &.{}) catch @panic("Could not find 'afl-cc', which is required to build"),
+            b.findProgram(&.{"afl-clang-lto"}, &.{}) catch @panic("Could not find 'afl-clang-lto', which is required to build"),
             "-O3",
             "-o",
         });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,6 +5,7 @@
         .AFLplusplus = .{
             .url = "git+https://github.com/allyourcodebase/AFLplusplus#73098eac7ec38baf978b0f22d17b283014fefe1c",
             .hash = "122004ec248ef4e2d9b9f4f71a969fd173fa1d6cbceccff1ecc3e07d8379a9d12548",
+            .lazy = true,
         },
     },
     .paths = .{


### PR DESCRIPTION
While it would be preferably to always use zig built AFLPlusPlus, this does not consistently work. On some systems (like ubuntu github runners), llvm uses C++11 abi for some functions. This leads to the functions having `B5cxx11` in the name. When zig compiles AFLPlusPlus, it misses this part of the name mangling. As such, the zig compile objects have different symbol names and failed to complete linking.

Since I was unable to resolve the above issue, I decided to enable avoiding zig compiled AFLPlusPlus. Instead, when the workaround is enabled, it will use `afl-cc` found in PATH.

-----

I am not sure this is worth merging into `zig-afl-kit`. I totally understand if it wants to stay pure instead of adding a system dependency. Hopefully a proper fix can be found at some point for the C++ name mangling. This is just the solution I am going with for now to enable fuzzing on ubuntu machines. Thought I would make a PR to share the workaround.