### PR TITLE
Update AFLplusplus version

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,8 +6,8 @@
     .minimum_zig_version = "0.14.0-dev.3451+d8d2aa9af",
     .dependencies = .{
         .AFLplusplus = .{
-            .url = "git+https://github.com/allyourcodebase/AFLplusplus#73098eac7ec38baf978b0f22d17b283014fefe1c",
-            .hash = "122004ec248ef4e2d9b9f4f71a969fd173fa1d6cbceccff1ecc3e07d8379a9d12548",
+            .url = "git+https://github.com/allyourcodebase/AFLplusplus#f708aa49a3d410533ab96f1fa998ba6e9f336eda",
+            .hash = "AFLplusplus-4.21.0-AAAAAL9rAAD1iyXhomXPucNejK1GJCBS4z0jp-tx-Otm",
             .lazy = true,
         },
     },


### PR DESCRIPTION
Avoids error:
```
/Users/bren077s/.cache/zig/p/AFLplusplus-4.21.0-AAAAAK9rAAAE7CSO9OLZufT3Gpaf0XP6HWy87M_x7MPg/build.zig:467:38: error: no field or member function named 'isWasm' in 'Target'
    if (enable_wafl and target.result.isWasm()) {
                        ~~~~~~~~~~~~~^~~~~~~
/Users/bren077s/vendor/zig-0.14.0/lib/std/Target.zig:1:1: note: struct declared here
//! All the details about the machine that will be executing code.
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    build: /Users/bren077s/.cache/zig/p/AFLplusplus-4.21.0-AAAAAK9rAAAE7CSO9OLZufT3Gpaf0XP6HWy87M_x7MPg/build.zig:96:25
    runBuild__anon_96908: /Users/bren077s/vendor/zig-0.14.0/lib/std/Build.zig:2428:44
    11 reference(s) hidden; use '-freference-trace=13' to see all references
```