### PR TITLE
return null when afl-cc is missing instead of panicking

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -70,12 +70,11 @@ pub fn addInstrumentedExe(
         run_afl_cc.step.dependOn(&install_tools.step);
     } else {
         run_afl_cc = b.addSystemCommand(&.{
-            b.findProgram(&.{"afl-cc"}, &.{}) catch @panic("Could not find 'afl-cc', which is required to build"),
+            b.findProgram(&.{"afl-cc"}, &.{}) catch return null,
             "-O3",
             "-o",
         });
     }
-    _ = obj.getEmittedBin(); // hack around build system bug
 
     const fuzz_exe = run_afl_cc.addOutputFileArg(obj.name);
     run_afl_cc.addFileArg(afl_kit.path("afl.c"));


### PR DESCRIPTION
closes #8

also remove 'hack around build system bug' which doesn't seem to be necessary anymore.  not sure when this was resolved but it doesn't seem necessary with 0.15.0-dev.1034+bd97b6618.

i've tested this out in my edn-data project and it solves all the problems from #8 where `zig build` required afl-cc to be found.  and i also was able to remove the previously necessary build flag.

i've also checked that fuzzing my project works when afl-cc is present. i cleared .zig-cache before checking.