### PR TITLE
Update aflplusplus commit

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .version = "0.1.0",
     .dependencies = .{
         .AFLplusplus = .{
-            .url = "git+https://github.com/allyourcodebase/AFLplusplus#a52f1376e2d49720c39e4abf4aa4944afbf82191",
-            .hash = "AFLplusplus-4.21.0-aA1y4UtxAABpnSIF7ARSYDMRyqNcI-2Rwa5UeSsuw70v",
+            .url = "git+https://github.com/allyourcodebase/AFLplusplus#7e65eb4262688a120bf830d145060aac0e5db920",
+            .hash = "AFLplusplus-4.21.0-aA1y4dZxAAAhqDy_JoRw3zwNSg8MenEGP7uJI_xNcYuV",
             .lazy = true,
         },
     },


### PR DESCRIPTION
The current commit does not compile with zig 0.15.2.
It makes it impossible to compile supermd when `zig-afl-kit` is already in the zig global cache, even though afl is not actually used. This repo is a transitive dependency of supermd via scripty.