### PR TITLE
Fix sancov guards to use linker-provided section boundaries

### DIFF
--- a/afl.c
+++ b/afl.c
@@ -19,10 +19,11 @@ void zig_fuzz_init();
 void zig_fuzz_test(unsigned char *, ssize_t);
 
 
-// bug in compilation causes init func to never get called
-// TODO: remove this once bug is fixed
-uint32_t __start___sancov_guards;
-uint32_t __stop___sancov_guards;
+// Linker-provided symbols marking the boundaries of the __sancov_guards section.
+// These must be declared extern so the linker provides the actual section boundaries
+// from the instrumented code, rather than creating new variables that shadow them.
+extern uint32_t __start___sancov_guards;
+extern uint32_t __stop___sancov_guards;
 void __sanitizer_cov_trace_pc_guard_init(uint32_t*, uint32_t*);
 
 


### PR DESCRIPTION
PR someone found with claude in Roc. Forwarding to the zig-afl-kit repo to fix as well.

-----

## Summary

The `__start___sancov_guards` and `__stop___sancov_guards` symbols were defined as regular variables, which shadowed the linker-generated symbols that point to the actual `__sancov_guards` section boundaries.

This caused AFL++ to see only ~7 edges instead of the full coverage map (~20K+ edges for a typical Zig project).

## The Fix

Change the declarations from:
```c
uint32_t __start___sancov_guards;
uint32_t __stop___sancov_guards;
```

To:
```c
extern uint32_t __start___sancov_guards;
extern uint32_t __stop___sancov_guards;
```

## Results

Testing with the Roc compiler's parser fuzzer:

| Metric | Before | After |
|--------|--------|-------|
| `edges_found` | 1 | **3,313** |
| `total_edges` | 7 | **20,854** |
| `stability` | 0.00% | **99.28%** |

🤖 Generated with [Claude Code](https://claude.ai/code)